### PR TITLE
Fix: 배포 타임아웃 시간 늘리기

### DIFF
--- a/appspec.yml
+++ b/appspec.yml
@@ -30,6 +30,6 @@ hooks:
     # 실행할 스크립트 또는 명령의 위치
     - location: deploy.sh
       # 스크립트 또는 명령 실행의 제한 시간을 설정
-      timeout: 60
+      timeout: 360
       # CodeDeploy 중 실행되는 스크립트 또는 명령을 실행할 사용자를 지정
       runas: ec2-user


### PR DESCRIPTION
close #55 

변경사항
-----
도커를 올릴 때 백그라운드로 실행되어 ec2에 컨테이너가 올리가는 것이 성공하나 code deploy상에서는 배포 타임아웃 시간 제한 때문에 실패라고 뜹니다.  deploy.sh 배포 타임아웃이 60초로 설정되어 있는데 넉넉하게 360 초로 늘렸습니다

개발하면서 발생한 문제점(에러, 어려움)
-----

해결방안 또는 새롭게 알게된 점
-----

당부하고 싶은 말 또는 논의해봐야할 점
-----
