### PR TITLE
Feat: 마이 페이지 API

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,12 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+
+    services:
+      redis:
+        image: redis:latest
+        ports:
+          - 6379:6379
     steps:
       - name: Chekcout Main Branch
         uses: actions/checkout@v3

--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,12 @@ dependencies {
 	//AWS
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 
+    //email
+    implementation'org.springframework.boot:spring-boot-starter-mail'
+
+	//redis가 포함된 테스트를 위함
+	testImplementation 'it.ozimov:embedded-redis:0.7.2'
+
 	// mac m1 error solve
 	if (osdetector.classifier == "osx-aarch_64") {
 		runtimeOnly("io.netty:netty-resolver-dns-native-macos:4.1.77.Final:${osdetector.classifier}")

--- a/src/main/java/potato/server/common/ResultCode.java
+++ b/src/main/java/potato/server/common/ResultCode.java
@@ -21,13 +21,14 @@ public enum ResultCode {
     // P3xx: 인증, 권한에 대한 예외
     AUTH_USER_NOT("P300", "현재 권한으로 접근 불가능합니다."),
     JWT_DATE_NOT("P301", "JWT토큰이 만료되었습니다."),
-    REFRESHTOKEN_OUTDATED("F302", "새로 발급된 토큰보다 이전의 리프레시 토큰입니다."),
+    REFRESHTOKEN_OUTDATED("P302", "새로 발급된 토큰보다 이전의 리프레시 토큰입니다."),
+    MAIL_AUTHNUMBER_NOT("P303", "인증번호가 틀립니다."),
 
     // P4xx: 유저 예외
     USER_NOT_FOUND("P400", "존재하지 않는 유저입니다."),
-    USER_ALREADY_JOIN("F401", "이미 회원가입된 유저입니다."),
-    USER_NOT_JOINED("F402", "회원가입이 되어있지 않은 유저입니다."),
-    USER_NOT_PERMISSION("F403", "권한이 없는 유저입니다."),
+    USER_ALREADY_JOIN("P401", "이미 회원가입된 유저입니다."),
+    USER_NOT_JOINED("P402", "회원가입이 되어있지 않은 유저입니다."),
+    USER_NOT_PERMISSION("P403", "권한이 없는 유저입니다."),
 
     // P5xx 주문예외
     ORDER_NOT_FOUND("P500", "존재하지 않는 주문입니다."),

--- a/src/main/java/potato/server/config/AsyncConfig.java
+++ b/src/main/java/potato/server/config/AsyncConfig.java
@@ -1,0 +1,32 @@
+package potato.server.config;
+
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig implements AsyncConfigurer {
+
+    @Override
+    @Bean(name = "mailExecutor")
+    public Executor getAsyncExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(5);
+        executor.setQueueCapacity(10);
+        executor.setThreadNamePrefix("Async MailExecutor-");
+        executor.initialize();
+        return executor;
+    }
+
+    @Override
+    public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
+        return AsyncConfigurer.super.getAsyncUncaughtExceptionHandler();
+    }
+}

--- a/src/main/java/potato/server/config/MailConfig.java
+++ b/src/main/java/potato/server/config/MailConfig.java
@@ -1,0 +1,42 @@
+package potato.server.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+
+/**
+ * 발송자는 임의로 제 아이디로 하였습니다.
+ * @Author 정순원
+ * @Since 2024-01-16
+ */
+@Configuration
+public class MailConfig {
+
+    @Value("${email.id}")
+    private String fromId;
+
+    @Value("${email.password}")
+    private String password;
+
+
+    @Bean
+    public JavaMailSender getJavaMailSender() {
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+
+        mailSender.setHost("smtp.gmail.com");
+        mailSender.setPort(465);
+        mailSender.setUsername(fromId);
+        mailSender.setPassword(password);
+
+        Properties props = mailSender.getJavaMailProperties();
+        props.put("mail.transport.protocol", "smtp");
+        props.put("mail.smtp.auth", "true");
+        props.put("mail.smtp.ssl.enable", "true");
+        props.put("mail.debug", "true");
+        return mailSender;
+    }
+}

--- a/src/main/java/potato/server/mail/AuthMailService.java
+++ b/src/main/java/potato/server/mail/AuthMailService.java
@@ -1,0 +1,40 @@
+package potato.server.mail;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import potato.server.mail.dto.AuthNumberResponse;
+import potato.server.mail.util.RandomGenerator;
+import potato.server.mail.util.SendMailService;
+import potato.server.redis.RedisUtil;
+
+
+/**
+ * @author 정순원
+ * @since 2024-01-16
+ */
+@Service
+@RequiredArgsConstructor
+public class AuthMailService {
+
+    private static final Long EXPIRATION = 1800000L; //한시간
+
+    private final RandomGenerator randomGenerator;
+    private final SendMailService sendMailService;
+    private final RedisUtil redisUtil;
+
+    @Transactional
+    public AuthNumberResponse sendCodeEmail(String email, String key) {
+            int authNumber = randomGenerator.makeRandomNumber();
+            String title = "Farmely 회원 가입 인증 이메일 입니다."; // 이메일 제목
+            String content =
+                    "홈페이지를 방문해주셔서 감사합니다." +    //html 형식으로 작성
+                            "<br><br>" +
+                            "인증 번호는 " + authNumber + "입니다." +
+                            "<br>" +
+                            "해당 인증번호를 인증번호 확인란에 기입하여 주세요."; //이메일 내용 삽입
+            sendMailService.sendEmail(email, title, content);
+            redisUtil.saveAuthNumber(key, String.valueOf(authNumber), EXPIRATION);  //인증번호 검증을 위해 레디스에 저장
+            return new AuthNumberResponse(authNumber);
+    }
+}

--- a/src/main/java/potato/server/mail/MailController.java
+++ b/src/main/java/potato/server/mail/MailController.java
@@ -1,0 +1,38 @@
+package potato.server.mail;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import potato.server.common.ResponseForm;
+import potato.server.mail.dto.AuthNumberResponse;
+import potato.server.mail.dto.SendMailRequest;
+import potato.server.security.auth.dto.AuthorityUserDTO;
+
+/**
+ * 메일 발송 관련 API
+ *
+ * @author 정순원
+ * @since 2024-01-16
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/mail")
+public class MailController {
+
+
+    private final AuthMailService authMailService;
+
+    /**
+     * 인증번호 보내기
+     */
+    @PreAuthorize("isAuthenticated()")
+    @PostMapping
+    public ResponseForm<AuthNumberResponse> sendEmail(@Valid @RequestBody SendMailRequest request, @AuthenticationPrincipal AuthorityUserDTO authorityUserDTO) {
+        return new ResponseForm<>(authMailService.sendCodeEmail(request.getEmail(), authorityUserDTO.getProviderId()));
+    }
+}

--- a/src/main/java/potato/server/mail/dto/AuthNumberResponse.java
+++ b/src/main/java/potato/server/mail/dto/AuthNumberResponse.java
@@ -1,0 +1,14 @@
+package potato.server.mail.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+/**
+ * @author 정순원
+ * @since 2024-01-16
+ */
+@Data
+@AllArgsConstructor
+public class AuthNumberResponse {
+    private int authNumber;
+}

--- a/src/main/java/potato/server/mail/dto/SendMailRequest.java
+++ b/src/main/java/potato/server/mail/dto/SendMailRequest.java
@@ -1,0 +1,17 @@
+package potato.server.mail.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * @author 정순원
+ * @since 2024-01-16
+ */
+@Data
+@NoArgsConstructor
+public class SendMailRequest {
+
+    @NotBlank
+    private String email;
+}

--- a/src/main/java/potato/server/mail/util/RandomGenerator.java
+++ b/src/main/java/potato/server/mail/util/RandomGenerator.java
@@ -1,0 +1,19 @@
+package potato.server.mail.util;
+
+import org.springframework.stereotype.Service;
+
+import java.util.Random;
+
+/**
+ * @Author 정순원
+ * @Since 2024-01-16
+ */
+@Service
+public class RandomGenerator {
+
+    private static final Random random = new Random();
+    public int makeRandomNumber() {
+        // 난수의 범위 111111 ~ 999999 (6자리 난수)
+        return  random.nextInt(888888) + 111111;
+    }
+}

--- a/src/main/java/potato/server/mail/util/SendMailService.java
+++ b/src/main/java/potato/server/mail/util/SendMailService.java
@@ -5,6 +5,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.mail.javamail.MimeMessagePreparator;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
 /**
@@ -20,6 +21,7 @@ public class SendMailService {
     @Value("${email.id}")
     private String fromId;
 
+    @Async("mailExecutor")
     public void sendEmail(String to, String subject, String content) {
         MimeMessagePreparator messagePreparator =
                 mimeMessage -> {

--- a/src/main/java/potato/server/mail/util/SendMailService.java
+++ b/src/main/java/potato/server/mail/util/SendMailService.java
@@ -1,0 +1,37 @@
+package potato.server.mail.util;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.mail.javamail.MimeMessagePreparator;
+import org.springframework.stereotype.Service;
+
+/**
+ * @author 정순원
+ * @since 2024-01-16
+ */
+@Service
+@RequiredArgsConstructor
+public class SendMailService {
+
+    private final JavaMailSender mailSender;
+
+    @Value("${email.id}")
+    private String fromId;
+
+    public void sendEmail(String to, String subject, String content) {
+        MimeMessagePreparator messagePreparator =
+                mimeMessage -> {
+                    //true는 멀티파트 메세지를 사용하겠다는 의미
+                    final MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, true, "UTF-8");
+                    helper.setFrom(fromId);
+                    helper.setTo(to);
+                    helper.setSubject(subject);
+                    helper.setText(content, true);
+                };
+        mailSender.send(messagePreparator);
+    }
+
+
+}

--- a/src/main/java/potato/server/redis/RedisUtil.java
+++ b/src/main/java/potato/server/redis/RedisUtil.java
@@ -15,6 +15,7 @@ import java.util.concurrent.TimeUnit;
 @Repository
 public class RedisUtil {
 
+    static final String AUTH_PREFIX = "AuthNumber_";
     private RedisTemplate redisTemplate;
 
     public RedisUtil(final RedisTemplate redisTemplate) {
@@ -25,13 +26,30 @@ public class RedisUtil {
     public void save(String key, String value, Long expiration) {
         redisTemplate.opsForValue().set(key, value, expiration, TimeUnit.MILLISECONDS);
     }
+
     public void update(String key, String value) {
         redisTemplate.opsForValue().set(key, value);
     }
+
     public void deleteByKey(String key) {
         redisTemplate.delete(String.valueOf(key));
     }
+
     public Object findByKey(String key) {
         return redisTemplate.opsForValue().get(key).toString();
+    }
+
+
+    //이메일 emailAuthNumber 관련 redis 명령어
+    public void saveAuthNumber(String key, String emailAuthNumber, Long expiration) {
+        redisTemplate.opsForValue().set(AUTH_PREFIX + key, emailAuthNumber, expiration, TimeUnit.MILLISECONDS);
+    }
+
+    public void updateAuthNumber(String key, String emailAuthNumber) {
+        redisTemplate.opsForValue().set(AUTH_PREFIX + key, emailAuthNumber);
+    }
+
+    public Object findEmailAuthNumberByKey(String key) {
+        return redisTemplate.opsForValue().get(AUTH_PREFIX + key);
     }
 }

--- a/src/main/java/potato/server/user/api/ProfileApi.java
+++ b/src/main/java/potato/server/user/api/ProfileApi.java
@@ -1,0 +1,52 @@
+package potato.server.user.api;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import potato.server.common.ResponseForm;
+import potato.server.security.auth.dto.AuthorityUserDTO;
+import potato.server.user.dto.request.UpdateEmailRequest;
+import potato.server.user.dto.request.UpdatePhoneNumberRequest;
+import potato.server.user.dto.request.UpdateProfileImageRequest;
+import potato.server.user.dto.response.ProfileImageUpdateResponse;
+import potato.server.user.dto.response.UserProfileResponse;
+import potato.server.user.service.ProfileService;
+
+/**
+ * @author 정순원
+ * @since 2024-01-15
+ */
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/v1/user/profile")
+@PreAuthorize("isAuthenticated()")
+public class ProfileApi {
+
+    private final ProfileService profileService;
+
+
+    @GetMapping
+    public ResponseForm<UserProfileResponse> getProfile(@AuthenticationPrincipal AuthorityUserDTO authorityUserDTO){
+        return new ResponseForm(profileService.getProfile(authorityUserDTO));
+    }
+
+    @PutMapping("/profile-image")
+    public ResponseForm<ProfileImageUpdateResponse> updateProfileImage(@Valid @RequestBody UpdateProfileImageRequest request, @AuthenticationPrincipal AuthorityUserDTO authorityUserDTO){
+        return new ResponseForm<>(profileService.updateProfileImage(request, authorityUserDTO));
+    }
+
+    @PutMapping("/email")
+    public ResponseForm updateEmail(@Valid @RequestBody UpdateEmailRequest request, @AuthenticationPrincipal AuthorityUserDTO authorityUserDTO){
+        profileService.updateEmail(request, authorityUserDTO);
+        return new ResponseForm<>();
+    }
+
+    @PutMapping("/phone-number")
+    public ResponseForm updatePhoneNumber(@Valid @RequestBody UpdatePhoneNumberRequest request, @AuthenticationPrincipal AuthorityUserDTO authorityUserDTO){
+        profileService.updatePhoneNumber(request, authorityUserDTO);
+        return new ResponseForm<>();
+    }
+}

--- a/src/main/java/potato/server/user/domain/User.java
+++ b/src/main/java/potato/server/user/domain/User.java
@@ -43,7 +43,7 @@ public class User extends BaseTimeEntity {
 	private JoinType joinType;
 	
 	@Column(length = 13, nullable = false)
-	private String number;
+	private String phoneNumber;
 
 	@Enumerated(EnumType.STRING)
 	private Authority authority = Authority.USER;
@@ -53,16 +53,30 @@ public class User extends BaseTimeEntity {
 
 	@NotNull
 	private String providerId;
+
+	private String profileImage;
 	
 	@Builder
-	public User(String email, String name, LocalDate birth, Gender gender, JoinType joinType, String number, String providerName, String providerId) {
+	public User(String email, String name, LocalDate birth, Gender gender, JoinType joinType, String phoneNumber, String providerName, String providerId, String profileImage) {
 		this.email = email;
 		this.name = name;
 		this.birth = birth;
 		this.gender = gender;
 		this.joinType = joinType;
-		this.number = number;
+		this.phoneNumber = phoneNumber;
 		this.providerName = providerName;
 		this.providerId = providerId;
+		this.profileImage = profileImage;
+	}
+
+	public void updateProfileImage(String profileImage) {
+		this.profileImage = profileImage;
+	}
+	public void updateEmail(String email) {
+		this.email = email;
+	}
+
+	public void updatePhoneNumber(String phoneNumber) {
+		this.phoneNumber = phoneNumber;
 	}
 }

--- a/src/main/java/potato/server/user/dto/request/UpdateEmailRequest.java
+++ b/src/main/java/potato/server/user/dto/request/UpdateEmailRequest.java
@@ -1,0 +1,17 @@
+package potato.server.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class UpdateEmailRequest {
+
+    @NotNull
+    private int authNumber;
+
+    @NotBlank
+    private String email;
+}

--- a/src/main/java/potato/server/user/dto/request/UpdatePhoneNumberRequest.java
+++ b/src/main/java/potato/server/user/dto/request/UpdatePhoneNumberRequest.java
@@ -1,0 +1,17 @@
+package potato.server.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * @author 정순원
+ * @since 2024-01-16
+ */
+@Data
+@NoArgsConstructor
+public class UpdatePhoneNumberRequest {
+
+    @NotBlank
+    private String phoneNumber;
+}

--- a/src/main/java/potato/server/user/dto/request/UpdateProfileImageRequest.java
+++ b/src/main/java/potato/server/user/dto/request/UpdateProfileImageRequest.java
@@ -1,0 +1,17 @@
+package potato.server.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * @author 정순원
+ * @since 2024-01-16
+ */
+@Data
+@NoArgsConstructor
+public class UpdateProfileImageRequest {
+
+    @NotBlank
+    private String fileName;
+}

--- a/src/main/java/potato/server/user/dto/response/ProfileImageUpdateResponse.java
+++ b/src/main/java/potato/server/user/dto/response/ProfileImageUpdateResponse.java
@@ -1,0 +1,15 @@
+package potato.server.user.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+/**
+ * @author 정순원
+ * @since 2024-01-16
+ */
+@Data
+@AllArgsConstructor
+public class ProfileImageUpdateResponse {
+
+    private String presignedURL;
+}

--- a/src/main/java/potato/server/user/dto/response/UserProfileResponse.java
+++ b/src/main/java/potato/server/user/dto/response/UserProfileResponse.java
@@ -1,0 +1,18 @@
+package potato.server.user.dto.response;
+
+import lombok.Data;
+import potato.server.user.domain.User;
+
+@Data
+public class UserProfileResponse {
+
+    private String profileImage;
+    private String email;
+    private String phoneNumber;
+
+    public UserProfileResponse(User user) {
+        this.profileImage = user.getProfileImage();
+        this.email = user.getEmail();
+        this.phoneNumber = user.getPhoneNumber();
+    }
+}

--- a/src/main/java/potato/server/user/service/ProfileService.java
+++ b/src/main/java/potato/server/user/service/ProfileService.java
@@ -1,0 +1,62 @@
+package potato.server.user.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import potato.server.common.CustomException;
+import potato.server.common.ResultCode;
+import potato.server.file.FileService;
+import potato.server.redis.RedisUtil;
+import potato.server.security.auth.dto.AuthorityUserDTO;
+import potato.server.user.domain.User;
+import potato.server.user.dto.request.UpdateEmailRequest;
+import potato.server.user.dto.request.UpdatePhoneNumberRequest;
+import potato.server.user.dto.request.UpdateProfileImageRequest;
+import potato.server.user.dto.response.ProfileImageUpdateResponse;
+import potato.server.user.dto.response.UserProfileResponse;
+
+/**
+ * @author 정순원
+ * @since 2023-10-13
+ */
+@Service
+@RequiredArgsConstructor
+public class ProfileService {
+
+    private final UserService userService;
+    private final RedisUtil redisUtil;
+    private final FileService fileService;
+
+    @Transactional(readOnly = true)
+    public UserProfileResponse getProfile(AuthorityUserDTO authorityUserDTO) {
+        User user = userService.getUserByProviderId(authorityUserDTO.getProviderId());
+        return new UserProfileResponse(user);
+    }
+
+    @Transactional
+    public ProfileImageUpdateResponse updateProfileImage(UpdateProfileImageRequest request, AuthorityUserDTO authorityUserDTO) {
+        String preSignedUrl = fileService.getPreSignedUrl(request.getFileName());
+        User user = userService.getUserByProviderId(authorityUserDTO.getProviderId());
+        user.updateProfileImage(preSignedUrl);
+        return new ProfileImageUpdateResponse(preSignedUrl);
+    }
+
+    @Transactional
+    public void updateEmail(UpdateEmailRequest request, AuthorityUserDTO authorityUserDTO) {
+        String savedAuthNumber = String.valueOf(redisUtil.findEmailAuthNumberByKey(authorityUserDTO.getProviderId()));
+        String requestAuthNumber = String.valueOf(request.getAuthNumber());
+        if (!savedAuthNumber.equals(requestAuthNumber))  //레디스에 저장한 인증번호와 다르다면 에러코드 보냄
+            throw new CustomException(HttpStatus.BAD_REQUEST, ResultCode.MAIL_AUTHNUMBER_NOT);
+
+        User user = userService.getUserByProviderId(authorityUserDTO.getProviderId());
+        user.updateEmail(request.getEmail());
+    }
+
+    //TODO 핸드폰 인증 어떻게 구현할 것인가
+    @Transactional
+    public void updatePhoneNumber(UpdatePhoneNumberRequest request, AuthorityUserDTO authorityUserDTO) {
+        User user = userService.getUserByProviderId(authorityUserDTO.getProviderId());
+        user.updatePhoneNumber(request.getPhoneNumber());
+    }
+}

--- a/src/main/java/potato/server/user/service/UserService.java
+++ b/src/main/java/potato/server/user/service/UserService.java
@@ -3,6 +3,7 @@ package potato.server.user.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import potato.server.common.CustomException;
 import potato.server.common.ResultCode;
 import potato.server.user.domain.User;
@@ -18,7 +19,15 @@ public class UserService {
 
     private final UserRepository userRepository;
 
-    public User getUserById(long Id) {
-        return userRepository.findById(Id).orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, ResultCode.USER_NOT_FOUND));
+
+    @Transactional
+    public User getUserById(Long id) {
+        return userRepository.findById(id).orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, ResultCode.USER_NOT_FOUND));
     }
+
+    @Transactional
+    public User getUserByProviderId(String providerId) {
+        return userRepository.findByProviderId(providerId).orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, ResultCode.USER_NOT_FOUND));
+    }
+
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -41,3 +41,8 @@ cloud:
       auto: false
     stack:
       auto: false
+
+email:
+  id: uglypotato5913@gmail.com
+  password: ldushxapuefwqfxn
+  expiration: 300000

--- a/src/test/java/potato/PotatoApiServerApplicationTests.java
+++ b/src/test/java/potato/PotatoApiServerApplicationTests.java
@@ -1,0 +1,7 @@
+package potato;
+
+import org.springframework.boot.test.context.SpringBootTest;
+
+//@SpringBootTest
+public class PotatoApiServerApplicationTests {
+}

--- a/src/test/java/potato/server/address/AddressAPITest.java
+++ b/src/test/java/potato/server/address/AddressAPITest.java
@@ -25,6 +25,10 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+/**
+ * @author 정순원
+ * @since 2024-01-16
+ */
 @SpringBootTest
 @AutoConfigureMockMvc
 class AddressAPITest {
@@ -40,7 +44,7 @@ class AddressAPITest {
     Address address3;
     User user;
     @Autowired
-    private ObjectMapper objectMapper;
+    ObjectMapper objectMapper;
 
     @BeforeEach
     void init()  {
@@ -51,7 +55,7 @@ class AddressAPITest {
                 .joinType(JoinType.KAKAO)
                 .gender(Gender.MALE)
                 .providerName("kakao")
-                .number("123-1234-1234")
+                .phoneNumber("123-1234-1234")
                 .build();
 
         userRepository.save(user);

--- a/src/test/java/potato/server/mail/MailApiTest.java
+++ b/src/test/java/potato/server/mail/MailApiTest.java
@@ -1,0 +1,55 @@
+package potato.server.mail;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import potato.server.common.WithMockCustomMember;
+import potato.server.mail.dto.SendMailRequest;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * @author 정순원
+ * @since 2024-01-16
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+class MailApiTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @BeforeEach
+    void init() {
+
+    }
+
+    @DisplayName("인증 메일 발송 테스트")
+    @Test
+    @Transactional
+    @WithMockCustomMember
+    void test1() throws Exception {
+
+        SendMailRequest sendMailRequest = new SendMailRequest();
+        sendMailRequest.setEmail("uglypotato5913@gmail.com");
+        String jsonRequest = objectMapper.writeValueAsString(sendMailRequest);
+
+        mockMvc.perform(post("/api/v1/mail")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonRequest))
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
+}

--- a/src/test/java/potato/server/user/profile/ProfileApiTest.java
+++ b/src/test/java/potato/server/user/profile/ProfileApiTest.java
@@ -1,0 +1,128 @@
+package potato.server.user.profile;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import potato.server.common.WithMockCustomMember;
+import potato.server.redis.RedisUtil;
+import potato.server.user.domain.User;
+import potato.server.user.dto.request.UpdateEmailRequest;
+import potato.server.user.dto.request.UpdatePhoneNumberRequest;
+import potato.server.user.dto.request.UpdateProfileImageRequest;
+import potato.server.user.repository.UserRepository;
+import potato.server.user.spec.Gender;
+import potato.server.user.spec.JoinType;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * @author 정순원
+ * @since 2024-01-16
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+class ProfileApiTest {
+
+    @Autowired
+    MockMvc mockMvc;
+    @Autowired
+    UserRepository userRepository;
+    @Autowired
+    RedisUtil redisUtil;
+    User user;
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void init() {
+        user = User.builder()
+                .name("sun won")
+                .email("test@test.com")
+                .providerId("kakao_test")
+                .joinType(JoinType.KAKAO)
+                .gender(Gender.MALE)
+                .providerName("kakao")
+                .phoneNumber("123-1234-1234")
+                .profileImage("imageURL")
+                .build();
+
+        userRepository.save(user);
+    }
+
+    @DisplayName("프로필 조회")
+    @Test
+    @Transactional
+    @WithMockCustomMember
+    void test1() throws Exception {
+        mockMvc.perform(get("/api/v1/user/profile"))
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
+
+    @DisplayName("프로필 이미지 수정")
+    @Test
+    @Transactional
+    @WithMockCustomMember
+    void test2() throws Exception {
+
+        UpdateProfileImageRequest updateProfileImageRequest = new UpdateProfileImageRequest();
+        updateProfileImageRequest.setFileName("imageFileName");
+        String jsonRequest = objectMapper.writeValueAsString(updateProfileImageRequest);
+
+        mockMvc.perform(put("/api/v1/user/profile/profile-image")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonRequest))
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
+
+    @DisplayName("이메일 수정")
+    @Test
+    @Transactional
+    @WithMockCustomMember
+    void test3() throws Exception {
+
+        final int authNumber = 1234;
+        redisUtil.saveAuthNumber("kakao_test", String.valueOf(authNumber), 1800000L);  //인증번호 검증을 위해 레디스에 저장
+
+        UpdateEmailRequest updateEmailRequest = new UpdateEmailRequest();
+        updateEmailRequest.setEmail("jsw5913@gmail.com");
+        updateEmailRequest.setAuthNumber(authNumber);
+
+        String jsonRequest = objectMapper.writeValueAsString(updateEmailRequest);
+
+        mockMvc.perform(put("/api/v1/user/profile/email")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonRequest))
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
+
+
+    @DisplayName("핸드폰 번호 수정")
+    @Test
+    @Transactional
+    @WithMockCustomMember
+    void test4() throws Exception {
+
+        UpdatePhoneNumberRequest updatePhoneNumberRequest = new UpdatePhoneNumberRequest();
+        updatePhoneNumberRequest.setPhoneNumber("010-3434-3434");
+        String jsonRequest = objectMapper.writeValueAsString(updatePhoneNumberRequest);
+
+        mockMvc.perform(put("/api/v1/user/profile/phone-number")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonRequest))
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
+}


### PR DESCRIPTION
close #60 
close #61 

변경사항
-----
- 프로필 사진 업데이트 api
- 핸드폰 번호 업데이트 api
  - 핸드폰 인증은 어떻게 구현 할 것인가 기획자님이랑 상의 후 추가
- 이메일 api 2개
   - 인증 이메일 보내기api
     -  JavaMailSender로 비동기로 보낸 후 Redis에 인증번호 저장
   - 인증번호 확인 하고 이메일 업데이트 api 
     - Redis에 저장되어 있는 인증번호와 비교

![image](https://github.com/ugly-potato1/potato-API-server/assets/92251131/732a61a4-49c1-48ed-a904-d82158187885)

개발하면서 발생한 문제점(에러, 어려움)
-----

해결방안 또는 새롭게 알게된 점
-----

당부하고 싶은 말 또는 논의해봐야할 점
-----
브랜치 이름을 잘못 지었습니다 ~