### PR TITLE
Feat: 상품 이미지 생성 및 삭제 API

### DIFF
--- a/src/main/java/potato/server/common/ResultCode.java
+++ b/src/main/java/potato/server/common/ResultCode.java
@@ -36,6 +36,7 @@ public enum ResultCode {
 
     // P6xx 상품예외
     PRODUCT_NOT_FOUND("P600", "존재하지 않은 상품입니다."),
+    PRODUCT_IMAGE_NOT_FOUND("P601", "존재하지 않는 상품이미지입니다."),
 
     // P7xx 리뷰예외
     REVIEW_NOT_FOUND("P700", "존재하지 않는 리뷰입니다."),

--- a/src/main/java/potato/server/product/api/ProductImageApi.java
+++ b/src/main/java/potato/server/product/api/ProductImageApi.java
@@ -1,0 +1,33 @@
+package potato.server.product.api;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import potato.server.common.ResponseForm;
+import potato.server.file.FileCreateRequest;
+import potato.server.product.dto.request.ProductImageCreateRequest;
+import potato.server.product.dto.request.ProductImageDeleteRequest;
+import potato.server.product.dto.response.ProductImageCreateResponse;
+import potato.server.product.service.ProductImageService;
+
+/**
+ * @author 정순원
+ * @since 2024-01-16
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/products/image")
+public class ProductImageApi {
+
+    private final ProductImageService productImageService;
+
+    @PostMapping
+    public ResponseForm<ProductImageCreateResponse> createProductImage(@RequestBody ProductImageCreateRequest request) {
+        return new ResponseForm<>(productImageService.createProductImage(request));
+    }
+
+    @DeleteMapping
+    public ResponseForm deleteProductImage(@RequestBody ProductImageDeleteRequest productImageDeleteRequest) {
+        productImageService.deleteProductImage(productImageDeleteRequest);
+        return new ResponseForm<>();
+    }
+}

--- a/src/main/java/potato/server/product/domain/ProductImage.java
+++ b/src/main/java/potato/server/product/domain/ProductImage.java
@@ -4,7 +4,6 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
 import potato.server.common.BaseTimeEntity;
 
 /**
@@ -33,5 +32,9 @@ public class ProductImage extends BaseTimeEntity {
     public ProductImage(Product product, String link) {
         this.product = product;
         this.link = link;
+    }
+
+    public void setProduct(Product product) {
+        this.product = product;
     }
 }

--- a/src/main/java/potato/server/product/dto/request/ProductCreateRequest.java
+++ b/src/main/java/potato/server/product/dto/request/ProductCreateRequest.java
@@ -2,16 +2,19 @@ package potato.server.product.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+
 import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author: 박건휘
  * @since: 2023-11-13
  */
 @Getter
-@AllArgsConstructor
+@NoArgsConstructor
 public class ProductCreateRequest {
 
     @NotBlank
@@ -25,4 +28,5 @@ public class ProductCreateRequest {
 
     @NotNull
     private Integer stock;
+    private List<Long> productImageIds = new ArrayList<>();
 }

--- a/src/main/java/potato/server/product/dto/request/ProductImageCreateRequest.java
+++ b/src/main/java/potato/server/product/dto/request/ProductImageCreateRequest.java
@@ -1,0 +1,17 @@
+package potato.server.product.dto.request;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * @author 정순원
+ * @since 2024-01-19
+ */
+
+@Data
+@NoArgsConstructor
+public class ProductImageCreateRequest {
+
+    private Long productId;
+    private String fileName;
+}

--- a/src/main/java/potato/server/product/dto/request/ProductImageDeleteRequest.java
+++ b/src/main/java/potato/server/product/dto/request/ProductImageDeleteRequest.java
@@ -1,0 +1,16 @@
+package potato.server.product.dto.request;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * @author 정순원
+ * @since 2024-01-16
+ */
+@Data
+@NoArgsConstructor
+public class ProductImageDeleteRequest {
+
+    private Long productImageId;
+    private String filePath;
+}

--- a/src/main/java/potato/server/product/dto/response/ProductImageCreateResponse.java
+++ b/src/main/java/potato/server/product/dto/response/ProductImageCreateResponse.java
@@ -1,0 +1,16 @@
+package potato.server.product.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+/**
+ * @author 정순원
+ * @since 2024-01-16
+ */
+@Data
+@AllArgsConstructor
+public class ProductImageCreateResponse {
+
+    private String url;
+    private Long productImageId;
+}

--- a/src/main/java/potato/server/product/repository/ProductImageRepository.java
+++ b/src/main/java/potato/server/product/repository/ProductImageRepository.java
@@ -1,0 +1,7 @@
+package potato.server.product.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import potato.server.product.domain.ProductImage;
+
+public interface ProductImageRepository extends JpaRepository<ProductImage, Long> {
+}

--- a/src/main/java/potato/server/product/service/ProductImageService.java
+++ b/src/main/java/potato/server/product/service/ProductImageService.java
@@ -1,0 +1,51 @@
+package potato.server.product.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import potato.server.file.FileCreateRequest;
+import potato.server.file.FileService;
+import potato.server.product.domain.Product;
+import potato.server.product.domain.ProductImage;
+import potato.server.product.dto.request.ProductImageCreateRequest;
+import potato.server.product.dto.request.ProductImageDeleteRequest;
+import potato.server.product.dto.response.ProductImageCreateResponse;
+import potato.server.product.repository.ProductImageRepository;
+import potato.server.product.repository.ProductRepository;
+
+/**
+ * @author 정순원
+ * @since 2024-01-16
+ */
+@Service
+@RequiredArgsConstructor
+public class ProductImageService {
+
+    private final ProductImageRepository productImageRepository;
+    private final FileService fileService;
+    private final ProductRepository productRepository;
+
+    @Transactional
+    public ProductImageCreateResponse createProductImage(ProductImageCreateRequest request) {
+        Product product = null;
+        String preSignedUrl = fileService.getPreSignedUrl(request.getFileName());
+
+        if(request.getProductId() != null)
+            product = productRepository.getReferenceById(request.getProductId());
+
+        ProductImage productImage = ProductImage.builder()
+                .product(product)
+                .link(preSignedUrl)
+                .build();
+        productImageRepository.save(productImage);
+
+        return new ProductImageCreateResponse(preSignedUrl, productImage.getId());
+    }
+
+    @Transactional
+    public void deleteProductImage(ProductImageDeleteRequest productImageDeleteRequest) {
+        fileService.deleteFile(productImageDeleteRequest.getFilePath());
+
+        productImageRepository.deleteById(productImageDeleteRequest.getProductImageId());
+    }
+}

--- a/src/main/java/potato/server/product/service/ProductService.java
+++ b/src/main/java/potato/server/product/service/ProductService.java
@@ -9,10 +9,12 @@ import org.springframework.transaction.annotation.Transactional;
 import potato.server.common.CustomException;
 import potato.server.common.ResultCode;
 import potato.server.product.domain.Product;
-import potato.server.product.dto.request.ProductUpdateRequest;
-import potato.server.product.repository.ProductRepository;
+import potato.server.product.domain.ProductImage;
 import potato.server.product.dto.request.ProductCreateRequest;
+import potato.server.product.dto.request.ProductUpdateRequest;
 import potato.server.product.dto.response.ProductResponse;
+import potato.server.product.repository.ProductImageRepository;
+import potato.server.product.repository.ProductRepository;
 
 import java.util.List;
 
@@ -25,6 +27,9 @@ import java.util.List;
 @Transactional
 public class ProductService {
     private final ProductRepository productRepository;
+    private final ProductImageRepository productImageRepository;
+
+    @Transactional
     public void createProduct(ProductCreateRequest request) {
         Product product = Product.builder()
                 .price(request.getPrice())
@@ -33,8 +38,19 @@ public class ProductService {
                 .stock(request.getStock())
                 .build();
         productRepository.save(product);
+
+        mapProductToProductImage(request.getProductImageIds(), product);
     }
 
+    private void mapProductToProductImage(List<Long> productImageIds, Product product) {
+        for (Long productImageId : productImageIds) {
+            ProductImage productImage = productImageRepository.findById(productImageId)
+                    .orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, ResultCode.PRODUCT_IMAGE_NOT_FOUND));
+            productImage.setProduct(product);
+        }
+    }
+
+    @Transactional
     public void deleteProduct(Long productId) {
         productRepository.deleteById(productId);
     }

--- a/src/main/java/potato/server/review/api/ReviewImageApi.java
+++ b/src/main/java/potato/server/review/api/ReviewImageApi.java
@@ -15,7 +15,7 @@ import potato.server.review.service.ReiewImageService;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("api/v1/review/image")
-public class ReviewImageUpdateApi {
+public class ReviewImageApi {
 
     private final ReiewImageService reiewImageService;
 


### PR DESCRIPTION
close #69 

변경사항
-----

- 상품이미지 생성 API
  -  상품id가 request에 있는 경우(상품 업데이트)엔 상품이미지 생성시 상품과 매핑
  -  상품 id가 request에 없는 경우(상품 최초 생성)엔 상품 생성할 때 상품이미지에 상품과 매핑
- 상품 생성 로직 수정
  - 상품 이미지에 생성된 상품과 매핑
- 상품 이미지 삭제 API
 
개발하면서 발생한 문제점(에러, 어려움)
-----

해결방안 또는 새롭게 알게된 점
-----

당부하고 싶은 말 또는 논의해봐야할 점
-----
